### PR TITLE
#6 Add mnemonic generation and loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@appliedblockchain/b-privacy": "^1.2.0",
+    "bitcore-mnemonic": "^1.5.0",
     "ganache-core": "^2.2.1",
     "web3": "1.0.0-beta.33"
   },

--- a/src/mantle.js
+++ b/src/mantle.js
@@ -1,6 +1,8 @@
 const BPrivacy = require('@appliedblockchain/b-privacy')
 const crypto = require('crypto')
 const Web3 = require('web3')
+const Mnemonic = require('bitcore-mnemonic')
+const secp256k1 = require('secp256k1')
 
 class Mantle {
   constructor(config = {}) {
@@ -8,11 +10,10 @@ class Mantle {
       throw new Error('No configuration provided: cannot initialize Mantle')
     }
 
-    this.keysGenerated = false
+    this.keysLoaded = false
     this.config = config
 
     this.setupWeb3Provider()
-    this.generateKeys()
   }
 
   get Web3() {
@@ -101,30 +102,73 @@ class Mantle {
   }
 
   /**
-   * Initialize an instance of BPrivacy in order to generate public, private and mnemonic keys
-   * @param  {*} [data] A seed, phrase, or entropy to initialize a mnemonic (optional)
+   * Derive a mnemonic/HD private key from the supplied seed (if applicable). If no
+   * seed is provided, then create a new mnemonic (this is exposed as mantle.mnemonic).
+   * The HD private key can be used to derive a HD public key and, later, private/public key pairs
+   * @param  {string} [seed=null] A 12 word mnemonic that acts as a seed in order to recover account information (optional)
    * @return {void}
    */
-  generateKeys(data) {
-    if (this.keysGenerated) {
-      throw new Error('Keys have already been generated')
+  loadMnemonic(seed = null) {
+    if (this.keysLoaded) {
+      throw new Error('Cannot load mnemonic: a mnemonic has already been loaded')
     }
 
-    const bPrivacy = new BPrivacy(data)
-    const { mnemonic, pubKey, pvtKey } = bPrivacy
+    const code = new Mnemonic(seed, Mnemonic.Words.ENGLISH)
+    const hdPrivateKey = code.toHDPrivateKey()
+    const hdPublicKey = hdPrivateKey.hdPublicKey
 
-    this.mnemonic = mnemonic
-    this.privateKey = pvtKey
-    this.publicKey = pubKey
+    this.mnemonic = code.phrase
+    this.hdPrivateKey = hdPrivateKey
+    this.hdPublicKey = hdPublicKey
+    this.privateKey = this.derivePrivateKey()
+    this.publicKey = this.derivePublicKey()
 
-    this.keysGenerated = true
+    this.keysLoaded = true
+  }
+
+  /**
+   * Derive a private key from our HDPrivateKey
+   * @param  {number} index=0
+   * @return {buffer}
+   */
+  derivePrivateKey(index = 0) {
+    if (!this.hdPrivateKey) {
+      throw new Error('Cannot derive a private key: no HD private key exists')
+    }
+
+    const account = 0
+    const coinType = 60 // 60: ethereum
+    const change = 0 // 0 (false): private address
+    const pathLevel = `44'/${coinType}'/${account}'/${change}`
+
+    // Private key derivation reference: https://bitcore.io/api/lib/hd-keys
+    const derivedChild = this.hdPrivateKey.derive(`m/${pathLevel}/${index}`)
+
+    // Includes big number(BN) and network
+    const privateKey = derivedChild.privateKey
+    // Access the big number(BN) and convert to a Buffer - this serves as our private key
+    return privateKey.bn.toBuffer({ size: 32 })
+  }
+
+  /**
+   * Derive a public key from our private key
+   * @return {buffer}
+   */
+  derivePublicKey() {
+    if (!this.privateKey) {
+      throw new Error('Cannot derive a public key: no private key exists')
+    }
+
+    return secp256k1.publicKeyCreate(this.privateKey, false).slice(1)
   }
 
   removeKeys() {
     this.mnemonic = null
+    this.hdPrivateKey = null
+    this.hdPublicKey = null
     this.privateKey = null
     this.publicKey = null
-    this.keysGenerated = false
+    this.keysLoaded = false
   }
 }
 

--- a/test/mantle.spec.js
+++ b/test/mantle.spec.js
@@ -1,6 +1,7 @@
 const Mantle = require('../src/mantle')
 const secp256k1 = require('secp256k1')
 const crypto = require('crypto')
+const Mnemonic = require('bitcore-mnemonic')
 const Ganache = require('ganache-core')
 const ganache = Ganache.server()
 
@@ -12,35 +13,76 @@ describe('Mantle', () => {
     }).toThrow(error)
   })
 
-  test('generates a mnemonic and private/public key pair upon initialization', () => {
-    const mantle = new Mantle()
-    const { mnemonic, publicKey, privateKey } = mantle
+  describe('Mnemonic/key generation', () => {
+    test('generates a mnemonic, hd keys and a private/public key pair via loadMnemonic()', () => {
+      const mantle = new Mantle()
+      mantle.loadMnemonic()
 
-    expect(mnemonic).toBeTruthy()
-    expect(privateKey).toBeTruthy()
-    expect(publicKey).toBeTruthy()
+      const { mnemonic, hdPublicKey, hdPrivateKey, publicKey, privateKey } = mantle
 
-    expect(mnemonic.split(' ').length).toEqual(12)
-    expect(Buffer.isBuffer(privateKey)).toBe(true)
-    expect(Buffer.isBuffer(publicKey)).toBe(true)
-  })
+      expect(mnemonic).toBeTruthy()
+      expect(hdPrivateKey).toBeTruthy()
+      expect(hdPublicKey).toBeTruthy()
+      expect(privateKey).toBeTruthy()
+      expect(publicKey).toBeTruthy()
 
-  test('throws an error if attempting to generate another set of keys', () => {
-    const mantle = new Mantle()
-    expect(() => {
-      mantle.generateKeys()
-    }).toThrow('Keys have already been generated')
-  })
+      expect(typeof mnemonic === 'string').toBe(true)
+      expect(mnemonic.split(' ').length).toEqual(12)
+      expect(Buffer.isBuffer(privateKey)).toBe(true)
+      expect(Buffer.isBuffer(publicKey)).toBe(true)
+    })
 
-  test('removes keys via removeKeys()', () => {
-    const mantle = new Mantle()
-    mantle.removeKeys()
+    test('generates different keys when not supplying a seed/mnemonic', () => {
+      const mantle1 = new Mantle()
+      const mantle2 = new Mantle()
 
-    const { mnemonic, publicKey, privateKey } = mantle
+      mantle1.loadMnemonic()
+      mantle2.loadMnemonic()
 
-    expect(mnemonic).toBe(null)
-    expect(privateKey).toBe(null)
-    expect(publicKey).toBe(null)
+      expect(mantle1.mnemonic).not.toEqual(mantle2.mnemonic)
+      expect(mantle1.hdPrivateKey).not.toEqual(mantle2.hdPrivateKey)
+      expect(mantle1.hdPrivateKey).not.toEqual(mantle2.hdPrivateKey)
+      expect(mantle1.privateKey).not.toEqual(mantle2.privateKey)
+      expect(mantle1.publicKey).not.toEqual(mantle2.publicKey)
+    })
+
+    test('generates the same keys when supplying a previously used seed/mnemonic to loadMnemonic()', () => {
+      const mnemonic = new Mnemonic(Mnemonic.Words.ENGLISH).phrase
+
+      const mantle1 = new Mantle()
+      const mantle2 = new Mantle()
+
+      mantle1.loadMnemonic(mnemonic)
+      mantle2.loadMnemonic(mnemonic)
+
+      expect(mantle1.mnemonic).toEqual(mantle2.mnemonic)
+      expect(mantle1.hdPrivateKey).toEqual(mantle2.hdPrivateKey)
+      expect(mantle1.hdPrivateKey).toEqual(mantle2.hdPrivateKey)
+      expect(mantle1.privateKey).toEqual(mantle2.privateKey)
+      expect(mantle1.publicKey).toEqual(mantle2.publicKey)
+    })
+
+    test('throws an error if attempting to load a mnemonic when keys have already been generated', () => {
+      const mantle = new Mantle()
+      mantle.loadMnemonic()
+      expect(() => {
+        mantle.loadMnemonic()
+      }).toThrow('Cannot load mnemonic: a mnemonic has already been loaded')
+    })
+
+    test('removes keys via removeKeys()', () => {
+      const mantle = new Mantle()
+      mantle.loadMnemonic()
+      mantle.removeKeys()
+
+      const { mnemonic, hdPublicKey, hdPrivateKey, publicKey, privateKey } = mantle
+
+      expect(mnemonic).toBe(null)
+      expect(hdPrivateKey).toBe(null)
+      expect(hdPublicKey).toBe(null)
+      expect(privateKey).toBe(null)
+      expect(publicKey).toBe(null)
+    })
   })
 
   describe('Web3 integration', () => {


### PR DESCRIPTION
@makevoid I assume we only want to create one set of keys per account so I throw an error if trying to generate another set of keys - BPrivacy seems to have no such restriction though so I'm a little unsure. Let me know if this should be changed.

Also how did you want the mnemonic loading to work? Currently it should just be accessible via `mantle.mnemonic` or `mantle.mnemonicKey.phrase` after initialization

Thanks