### PR TITLE
change a number of instance methods to static methods

### DIFF
--- a/src/mantle.js
+++ b/src/mantle.js
@@ -81,7 +81,7 @@ class Mantle {
     this.web3 = web3
   }
 
-  createSharedSecret() {
+  static createSharedSecret() {
     const BYTE_LENGTH = 32
     return crypto.randomBytes(BYTE_LENGTH)
   }
@@ -108,7 +108,7 @@ class Mantle {
    * @param  {string} privateKey
    * @return {*}
    */
-  decrypt(data, privateKey) {
+  static decrypt(data, privateKey) {
     try {
       return BPrivacy.decrypt(data, privateKey)
     } catch (err) {
@@ -121,7 +121,7 @@ class Mantle {
    * @param  {byte} secret A 32 byte secret
    * @return {buffer} A 16 byte initialization vector followed by encrypted data
    */
-  encryptSymmetric(data, secret) {
+  static encryptSymmetric(data, secret) {
     try {
       return BPrivacy.encryptSymmetric(data, secret)
     } catch (err) {
@@ -134,7 +134,7 @@ class Mantle {
    * @param  {byte} secret A 32 byte secret
    * @return {*} A decrypted value
    */
-  decryptSymmetric(data, secret) {
+  static decryptSymmetric(data, secret) {
     try {
       return BPrivacy.decryptSymmetric(data, secret)
     } catch (err) {
@@ -267,7 +267,7 @@ class Mantle {
    * @param  {hex0x} ecSignature An ECDSA generated signature
    * @return {hex0x}
    */
-  recover(hash, ecSignature) {
+  static recover(hash, ecSignature) {
     // Convert hash and ecSignature to buffers to conform with secp256k1.recover required argument types
     const hashBuffer = Buffer.from(hash.slice(2), 'hex')
     if (hashBuffer.length !== 32) {

--- a/test/mantle.spec.js
+++ b/test/mantle.spec.js
@@ -78,7 +78,7 @@ describe('Mantle', () => {
       const invalidHash = '@invalid_hash'
 
       expect(() => {
-        mantle.recover(invalidHash, signature)
+        Mantle.recover(invalidHash, signature)
       }).toThrow()
     })
 
@@ -92,7 +92,7 @@ describe('Mantle', () => {
       const invalidSignature = '@invalid_signature'
 
       expect(() => {
-        mantle.recover(hash, invalidSignature)
+        Mantle.recover(hash, invalidSignature)
       }).toThrow()
     })
 
@@ -102,7 +102,7 @@ describe('Mantle', () => {
 
       mantle.loadMnemonic()
       const signature = mantle.sign(hash)
-      const publicKey = mantle.recover(hash, signature)
+      const publicKey = Mantle.recover(hash, signature)
 
       expect(publicKey).toEqual('0x' + mantle.publicKey.toString('hex'))
     })
@@ -316,7 +316,7 @@ describe('Mantle', () => {
         const encryptedData = mantle.encrypt(data, publicKey).toString('hex')
         expect(encryptedData).not.toEqual(data)
 
-        const decryptedData = mantle.decrypt(encryptedData, privateKey)
+        const decryptedData = Mantle.decrypt(encryptedData, privateKey)
         expect(decryptedData).toEqual(data)
       })
     })
@@ -325,19 +325,19 @@ describe('Mantle', () => {
       let secret
 
       beforeAll(() => {
-        secret = mantle.createSharedSecret()
+        secret = Mantle.createSharedSecret()
       })
 
       test('provides symmetric encryption via encryptSymmetric()', () => {
-        const encryptedData = mantle.encryptSymmetric(data, secret)
+        const encryptedData = Mantle.encryptSymmetric(data, secret)
 
         expect(Buffer.isBuffer(encryptedData)).toBe(true)
         expect(encryptedData.toString()).not.toEqual(data)
       })
 
       test('provides symmetric decryption via decryptSymmetric()', () => {
-        const encryptedData = mantle.encryptSymmetric(data, secret)
-        const decryptedData = mantle.decryptSymmetric(encryptedData, secret)
+        const encryptedData = Mantle.encryptSymmetric(data, secret)
+        const decryptedData = Mantle.decryptSymmetric(encryptedData, secret)
         expect(decryptedData).toEqual(data)
       })
     })


### PR DESCRIPTION
Proposing to change the following instance methods to static methods:
- `encryptSymmetric`
- `decryptSymmetric`
- `decrypt`
- `recover`
- `createSharedSecret`

This should provide more intuitive usage. For example, there should be no need to instantiate an instance of Mantle where wanting to create a shared secret or performing symmetric encryption (since all arguments are supplied and do not depend on internal Mantle state).