### PR TITLE
change encrypt and sign methods to static

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Mantle SDK repository
 
 `const mantle = new Mantle()`
 
-The mantle instance exposes methods to facilitate, amongst other things, asymmetric/symmetric encryption/decryption, mnemonic and HD public/private key generation etc.
+The mantle instance exposes methods to facilitate, amongst other things, mnemonic and HD public/private key generation, IPFS API access etc.
 
 ### Mnemonic generation
 
@@ -14,7 +14,7 @@ Mnemonic, HD private/public keys and private/public keys are generated via `load
 
 ### Symmetric encryption
 
-Facilitated via the `encryptSymmetric` and `decryptSymmetric` methods. Shared secrets can be generated via `createSharedSecret`.
+Facilitated via the `encryptSymmetric` and `decryptSymmetric` static methods. Shared secrets can be generated via `createSharedSecret`.
 
 # IPFS setup
 
@@ -50,20 +50,20 @@ mantle.loadMnemonic('tragic panic toast hazard royal marine visual laptop salmon
 ```js
 const data = 'foo'
 
-const encrypted = mantle.encrypt(data, mantle.publicKey) // Returns a buffer
+const encrypted = Mantle.encrypt(data, mantle.publicKey) // Returns a buffer
 
-const decrypted = mantle.decrypt(encrypted, mantle.privateKey) // 'foo'
+const decrypted = Mantle.decrypt(encrypted, mantle.privateKey) // 'foo'
 ```
 
 ### Symmetric encryption/decryption
 
 ```js
 const data = 'foo'
-const secret = mantle.createSharedSecret()
+const secret = Mantle.createSharedSecret()
 
-const encrypted = mantle.encryptSymmetric(data, secret) // Returns a Buffer
+const encrypted = Mantle.encryptSymmetric(data, secret) // Returns a Buffer
 
-const decrypted = mantle.decryptSymmetric(encrypted, secret) // 'foo'
+const decrypted = Mantle.decryptSymmetric(encrypted, secret) // 'foo'
 ```
 
 # Local testing

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mantle",
+  "name": "@appliedblockchain/mantle",
   "version": "1.0.0",
   "description": "Mantle is a blockchain SDK targeting Ethereum and Hyperledger Fabric",
   "main": "src/mantle.js",

--- a/src/mantle.js
+++ b/src/mantle.js
@@ -92,10 +92,10 @@ class Mantle {
    * @param  {string} publicKey
    * @return {buffer}
    */
-  encrypt(data, publicKey) {
+  static encrypt(data, publicKey) {
     try {
       // Generate private key
-      const privateKey = this.web3.eth.accounts.create().privateKey.toString()
+      const privateKey = new Web3().eth.accounts.create().privateKey.toString()
       return BPrivacy.encrypt(data, privateKey, publicKey)
     } catch (err) {
       throw new Error(err)
@@ -237,10 +237,11 @@ class Mantle {
    * - 32-byte scalar `s` (part of the ECDSA signature)
    * - A recovery id `v` used for public key recovery
    * @param  {hex0x} hash
+   * @param  {buffer} privateKey
    * @return {hex0x}
    */
-  sign(hash) {
-    if (!this.privateKey) {
+  static sign(hash, privateKey) {
+    if (!privateKey) {
       throw new Error('Cannot sign message: private key required')
     }
 
@@ -251,7 +252,7 @@ class Mantle {
     // Convert hash to buffer to conform with secp256k1.sign required argument types
     const hashBuffer = Buffer.from(hash.slice(2), 'hex')
 
-    const { signature, recovery } = secp256k1.sign(hashBuffer, this.privateKey)
+    const { signature, recovery } = secp256k1.sign(hashBuffer, privateKey)
 
     const RECOVERY_ID = 27
     const r = signature.slice(0, 32).toString('hex')

--- a/test/mantle.spec.js
+++ b/test/mantle.spec.js
@@ -38,10 +38,9 @@ describe('Mantle', () => {
   describe('Signing', () => {
     test('throws an error when no private key exists', () => {
       const hash = Mantle.generateHash(data)
-      const mantle = new Mantle()
 
       expect(() => {
-        mantle.sign(hash)
+        Mantle.sign(hash)
       }).toThrow()
     })
 
@@ -51,7 +50,7 @@ describe('Mantle', () => {
 
       mantle.loadMnemonic()
       expect(() => {
-        mantle.sign(hash)
+        Mantle.sign(hash, mantle.privateKey)
       }).toThrow()
     })
 
@@ -60,7 +59,7 @@ describe('Mantle', () => {
       const mantle = new Mantle()
 
       mantle.loadMnemonic()
-      const signature = mantle.sign(hash)
+      const signature = Mantle.sign(hash, mantle.privateKey)
 
       expect(signature).toBeTruthy()
       expect(signature.startsWith('0x')).toBe(true)
@@ -73,7 +72,7 @@ describe('Mantle', () => {
       const mantle = new Mantle()
 
       mantle.loadMnemonic()
-      const signature = mantle.sign(hash)
+      const signature = Mantle.sign(hash, mantle.privateKey)
 
       const invalidHash = '@invalid_hash'
 
@@ -87,7 +86,7 @@ describe('Mantle', () => {
       const mantle = new Mantle()
 
       mantle.loadMnemonic()
-      mantle.sign(hash)
+      Mantle.sign(hash, mantle.privateKey)
 
       const invalidSignature = '@invalid_signature'
 
@@ -101,7 +100,7 @@ describe('Mantle', () => {
       const mantle = new Mantle()
 
       mantle.loadMnemonic()
-      const signature = mantle.sign(hash)
+      const signature = Mantle.sign(hash, mantle.privateKey)
       const publicKey = Mantle.recover(hash, signature)
 
       expect(publicKey).toEqual('0x' + mantle.publicKey.toString('hex'))
@@ -307,13 +306,13 @@ describe('Mantle', () => {
       })
 
       test('provides asymmetric encryption via encrypt()', () => {
-        const encryptedData = mantle.encrypt(data, publicKey).toString('hex')
+        const encryptedData = Mantle.encrypt(data, publicKey).toString('hex')
         expect(encryptedData).toHaveLength(236)
         expect(encryptedData.slice(0, 2)).toBe('04')
       })
 
       test('provides asymmetric decryption via decrypt()', () => {
-        const encryptedData = mantle.encrypt(data, publicKey).toString('hex')
+        const encryptedData = Mantle.encrypt(data, publicKey).toString('hex')
         expect(encryptedData).not.toEqual(data)
 
         const decryptedData = Mantle.decrypt(encryptedData, privateKey)


### PR DESCRIPTION
More static method changes and updated readme (#27). Also changed to scoped package name so that we can deploy privately on npm for the Toyota project integration (can be changed back to public package once API is fully reviewed and approved)