### PR TITLE
add method to recover address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mantle",
+  "name": "@appliedblockchain/mantle",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -10675,7 +10675,8 @@
         "pem-jwk": "^1.5.1",
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0"
+        "tweetnacl": "^1.0.0",
+        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
       },
       "dependencies": {
         "asn1.js": {
@@ -10710,10 +10711,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -11774,7 +11771,14 @@
             "pem-jwk": "^1.5.1",
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0"
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "webcrypto-shim": {
+              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+              "from": "github:dignifiedquire/webcrypto-shim#master"
+            }
           }
         },
         "lodash": {
@@ -14369,6 +14373,10 @@
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
       }
+    },
+    "webcrypto-shim": {
+      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+      "from": "github:dignifiedquire/webcrypto-shim#master"
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@appliedblockchain/b-privacy": "^1.2.0",
     "bitcore-mnemonic": "^1.5.0",
-    "ethereumjs-util": "^5.2.0",
     "ganache-core": "^2.2.1",
     "ipfs-api": "^24.0.1",
     "web3": "1.0.0-beta.33"

--- a/src/mantle.js
+++ b/src/mantle.js
@@ -7,7 +7,6 @@ const Config = require('./config')
 const IPFS = require('./ipfs')
 const errors = require('./errors')
 const { bufferToOther, bytesToBuffer } = require('./utils/conversions')
-const ethUtils = require('ethereumjs-util')
 
 class Mantle {
   constructor(config) {
@@ -185,9 +184,9 @@ class Mantle {
       throw new Error('Cannot derive an ethereum address: no private key exists')
     }
 
-    const address = ethUtils.privateToAddress(this.privateKey)
-    const checksumAddress = ethUtils.toChecksumAddress('0x' + address.toString('hex'))
-    return checksumAddress
+    const privateKey = bufferToOther(this.privateKey, 'hex0x')
+    const { address } = this.web3.eth.accounts.privateKeyToAccount(privateKey)
+    return address
   }
 
   /**

--- a/test/mantle.spec.js
+++ b/test/mantle.spec.js
@@ -4,10 +4,9 @@ const defaults = require('../src/defaults')
 const errors = require('../src/errors')
 const secp256k1 = require('secp256k1')
 const Mnemonic = require('bitcore-mnemonic')
-const { fromAscii } = require('web3-utils')
+const { fromAscii, checkAddressChecksum } = require('web3-utils')
 const { isHex, isHex0x } = require('../src/utils/typeChecks')
 const Ganache = require('ganache-core')
-const ethUtils = require('ethereumjs-util')
 
 describe('Mantle', () => {
   let server, data
@@ -202,7 +201,8 @@ describe('Mantle', () => {
 
       expect(typeof address === 'string').toBe(true)
       expect(address.startsWith('0x')).toBe(true)
-      expect(ethUtils.isValidChecksumAddress(address)).toBe(true)
+
+      expect(checkAddressChecksum(address)).toBe(true)
       expect(typeof mnemonic === 'string').toBe(true)
       expect(mnemonic.split(' ').length).toEqual(12)
       expect(Buffer.isBuffer(privateKey)).toBe(true)


### PR DESCRIPTION
For some reason address recovery was not working when the address was derived from web3's `eth.accounts.privateKeyToAccount` method. The address on a mantle instance (i.e. the one created by web3) and the address returned from `BPrivacy.publicKeyToAddress` were different. 

Switching to ethereumjs-util to generate the address resolved the issue.

EDIT: Issue was that the privateKeyToAccount expects the private key to be prefixed with '0x'