### PR TITLE
change signing and hashing implementation

### DIFF
--- a/src/mantle.js
+++ b/src/mantle.js
@@ -29,12 +29,12 @@ class Mantle {
   }
 
   /**
-   * Generates a hash from a list of values
-   * @param  {*} ...args
+   * Generates a hash from the given string
+   * @param  {string} message
    * @return {hex0x}
    */
-  static generateHash(...args) {
-    return BPrivacy.callHash(...args)
+  static generateHash(message) {
+    return BPrivacy.callHash(message)
   }
 
   /**
@@ -243,15 +243,16 @@ class Mantle {
    * - 32-byte scalar `r` (part of the ECDSA signature)
    * - 32-byte scalar `s` (part of the ECDSA signature)
    * - A recovery id `v` used for public key recovery
-   * @param  {byte} hash
+   * @param  {string} message
    * @param  {buffer} privateKey
    * @return {hex0x}
    */
-  static sign(hash, privateKey) {
+  static sign(message, privateKey) {
     if (!privateKey) {
       throw new Error('Cannot sign message: private key required')
     }
 
+    const hash = Mantle.generateHash(message)
     // Convert hash to buffer to conform with secp256k1.sign required argument types
     const hashBuffer = bytesToBuffer(hash)
 

--- a/test/mantle.spec.js
+++ b/test/mantle.spec.js
@@ -64,22 +64,20 @@ describe('Mantle', () => {
       }).toThrow()
     })
 
-    test('throws an error when providing an invalid hash', () => {
-      const hash = '@invalid_hash'
+    test('throws an error when providing an invalid message', () => {
       const mantle = new Mantle()
 
       mantle.loadMnemonic()
       expect(() => {
-        Mantle.sign(hash, mantle.privateKey)
+        Mantle.sign(null, mantle.privateKey)
       }).toThrow()
     })
 
     test('generates a message signature via sign()', () => {
-      const hash = Mantle.generateHash(data)
       const mantle = new Mantle()
 
       mantle.loadMnemonic()
-      const signature = Mantle.sign(hash, mantle.privateKey)
+      const signature = Mantle.sign(data, mantle.privateKey)
 
       expect(signature).toBeTruthy()
       expect(signature.startsWith('0x')).toBe(true)
@@ -88,11 +86,10 @@ describe('Mantle', () => {
 
   describe('Recovery', () => {
     test('throws an error when providing an invalid hash', () => {
-      const hash = Mantle.generateHash(data)
       const mantle = new Mantle()
 
       mantle.loadMnemonic()
-      const signature = Mantle.sign(hash, mantle.privateKey)
+      const signature = Mantle.sign(data, mantle.privateKey)
 
       const invalidHash = '@invalid_hash'
 
@@ -106,7 +103,7 @@ describe('Mantle', () => {
       const mantle = new Mantle()
 
       mantle.loadMnemonic()
-      Mantle.sign(hash, mantle.privateKey)
+      Mantle.sign(data, mantle.privateKey)
 
       const invalidSignature = '@invalid_signature'
 
@@ -120,7 +117,7 @@ describe('Mantle', () => {
       const mantle = new Mantle()
 
       mantle.loadMnemonic()
-      const signature = Mantle.sign(hash, mantle.privateKey)
+      const signature = Mantle.sign(data, mantle.privateKey)
       const publicKey = Mantle.recover(hash, signature)
 
       expect(publicKey).toEqual('0x' + mantle.publicKey.toString('hex'))


### PR DESCRIPTION
Proposal to change the **generateHash,** and **sign** methods, using the Toyota project to highlight examples.

**generateHash**
- Currently takes any number of `args`. Not quite sure why the BPrivacy takes args in spread operator format but I believe this can be simplified by passing a string.
- Before: 
```js
Mantle.generateHash('register', address, publicKey)
```
- After: 
```js
Mantle.generateHash(`register ${address} ${publicKey}`)
```

**sign**
- Currently expects to receive the hash of a message. This can be simplified by passing the message directly as a string and performing the hashing internally. This also conforms more to the web3 standard (https://web3js.readthedocs.io/en/1.0/web3-eth-accounts.html#sign)
- Before:
```js
const hash = Mantle.generateHash('register', address, publicKey)
const sig = Mantle.sign(hash, this.mantle.privateKey)
```
- After: 
```js
Mantle.sign(`register ${address} ${publicKey}`, this.mantle.privateKey)
```

recovery remains the same - in order to recover a public key or address you first need to hash the msg and perform a call with the relevant signature:
```js
const recovered = Mantle.recover(hash, sig)
```